### PR TITLE
feat: Replace `flake-utils` input with plain `nixpkgs.lib.genAttrs`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -1,23 +1,5 @@
 {
   "nodes": {
-    "flake-utils": {
-      "inputs": {
-        "systems": "systems"
-      },
-      "locked": {
-        "lastModified": 1731533236,
-        "narHash": "sha256-l0KFg5HjrsfsO/JpG+r7fRrqm12kzFHyUHqHCVpMMbI=",
-        "owner": "numtide",
-        "repo": "flake-utils",
-        "rev": "11707dc2f618dd54ca8739b309ec4fc024de578b",
-        "type": "github"
-      },
-      "original": {
-        "owner": "numtide",
-        "repo": "flake-utils",
-        "type": "github"
-      }
-    },
     "nixpkgs": {
       "locked": {
         "lastModified": 1783224372,
@@ -36,23 +18,7 @@
     },
     "root": {
       "inputs": {
-        "flake-utils": "flake-utils",
         "nixpkgs": "nixpkgs"
-      }
-    },
-    "systems": {
-      "locked": {
-        "lastModified": 1681028828,
-        "narHash": "sha256-Vy1rq5AaRuLzOxct8nz4T6wlgyUR7zLU309k9mBC768=",
-        "owner": "nix-systems",
-        "repo": "default",
-        "rev": "da67096a3b9bf56a91d16901293e51ba5b49a27e",
-        "type": "github"
-      },
-      "original": {
-        "owner": "nix-systems",
-        "repo": "default",
-        "type": "github"
       }
     }
   },

--- a/flake.nix
+++ b/flake.nix
@@ -10,10 +10,10 @@
     }:
     let
       systems = [
-        "x86_64-linux"
-        "i686-linux"
-        "aarch64-linux"
         "aarch64-darwin"
+        "aarch64-linux"
+        "x86_64-darwin"
+        "x86_64-linux"
       ];
       forAllSystems = nixpkgs.lib.genAttrs systems;
     in

--- a/flake.nix
+++ b/flake.nix
@@ -1,47 +1,64 @@
 {
   description = "Official Nix packaging for Herdr release binaries";
 
-  inputs = {
-    nixpkgs.url = "github:NixOS/nixpkgs/nixos-unstable";
-    flake-utils.url = "github:numtide/flake-utils";
-  };
+  inputs.nixpkgs.url = "github:NixOS/nixpkgs/nixos-unstable";
 
   outputs =
-    { self, nixpkgs, flake-utils }:
-    flake-utils.lib.eachDefaultSystem (
-      system:
-      let
-        pkgs = import nixpkgs { inherit system; };
-        herdr = pkgs.callPackage ./package.nix { };
-      in
-      {
-        packages = {
-          inherit herdr;
+    {
+      self,
+      nixpkgs,
+    }:
+    let
+      systems = [
+        "x86_64-linux"
+        "i686-linux"
+        "aarch64-linux"
+        "aarch64-darwin"
+      ];
+      forAllSystems = nixpkgs.lib.genAttrs systems;
+    in
+    {
+      packages = forAllSystems (
+        system:
+        let
+          pkgs = nixpkgs.legacyPackages.${system};
+        in
+        rec {
+          herdr = pkgs.callPackage ./package.nix { };
           default = herdr;
-        };
+        }
+      );
 
-        apps.default = {
-          type = "app";
-          program = "${herdr}/bin/herdr";
-        };
+      apps.default = forAllSystems (system: {
+        type = "app";
+        program = nixpkgs.lib.getExe self.packages.${system}.default;
+      });
 
-        checks = {
-          inherit herdr;
-          scripts = pkgs.runCommand "herdr-nix-scripts" {
-            nativeBuildInputs = [
-              pkgs.bats
-              pkgs.python3
-              pkgs.shellcheck
-            ];
-          } ''
-            cp -R ${./.} source
-            chmod -R u+w source
-            cd source
-            shellcheck update.sh
-            bats tests
-            touch "$out"
-          '';
-        };
-      }
-    );
+      checks = forAllSystems (
+        system:
+        let
+          pkgs = nixpkgs.legacyPackages.${system};
+        in
+        {
+          herdr = self.packages.${system}.herdr;
+          scripts =
+            pkgs.runCommand "herdr-nix-scripts"
+              {
+                nativeBuildInputs = [
+                  pkgs.bats
+                  pkgs.python3
+                  pkgs.shellcheck
+                ];
+              }
+              ''
+                cp -R ${./.} source
+                chmod -R u+w source
+                cd source
+                shellcheck update.sh
+                bats tests
+                touch "$out"
+              '';
+        }
+      );
+    };
 }


### PR DESCRIPTION
The `eachDefaultSystem` function from `flake-utils` can be replaced with the following code snippet:

```nix
systems = [
  "aarch64-darwin"
  "aarch64-linux"
  "x86_64-darwin"
  "x86_64-linux"
];
forAllSystems = nixpkgs.lib.genAttrs systems;
```

This reduces the dependency footprint for the Nix flake, as it is explained in the following article:

> nixpkgs.lib.genAttrs offers a more direct, built-in alternative. Using it with an explicit list of systems gives you clear control without an extra dependency.

Source: https://nixcademy.com/posts/1000-instances-of-flake-utils/

Additionally, `nixpkgs.legacyPackages.${system}` is used in favor of `import nixpkgs { inherit system; }` to avoid creating too many instances of `nixpkgs` as it is explained in the following article:

> Instead of instantiating a new nixpkgs, access nixpkgs.legacyPackages.$ and then make sure that all dependencies use the same instance of nixpkgs.

Source: https://zimbatm.com/notes/1000-instances-of-nixpkgs/